### PR TITLE
deployer: kick out all components before shutdown and destroying the ORB

### DIFF
--- a/bin/deployer-corba.cpp
+++ b/bin/deployer-corba.cpp
@@ -165,58 +165,62 @@ int main(int argc, char** argv)
             // none) after "--"
             TaskContextServer::InitOrb( argc - taoIndex, &argv[taoIndex] );
 
-            OCL::CorbaDeploymentComponent dc( name, siteFile );
-
-            if (0 == TaskContextServer::Create( &dc, true, requireNameService ))
-                {
-                    return -1;
-                }
-
-            // The orb thread accepts incomming CORBA calls.
-            TaskContextServer::ThreadOrb();
-
-            /* Only start the scripts after the Orb was created. Processing of
-               scripts stops after the first failed script, and -1 is returned.
-               Whether a script failed or all scripts succeeded, in non-daemon
-               and non-checking mode the TaskBrowser will be run to allow
-               inspection.
-             */
-            bool result = true;
-            for (std::vector<std::string>::const_iterator iter=scriptFiles.begin();
-                 iter!=scriptFiles.end() && result;
-                 ++iter)
+            // scope to force dc destruction prior to memory free and Orb shutdown
             {
-                if ( !(*iter).empty() )
-                {
-                    if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
-                        if ( deploymentOnlyChecked ) {
-                            if (!dc.loadComponents( (*iter) )) {
-                                result = false;
-                                log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
-                            } else if (!dc.configureComponents()) {
-                                result = false;
-                                log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
-                            }
-                            // else leave result=true and continue
-                        } else {
-                            result = dc.kickStart( (*iter) );
-                        }
-                        continue;
-                    } if ( (*iter).rfind(".ops",string::npos) == (*iter).length() - 4 || (*iter).rfind(".osd",string::npos) == (*iter).length() - 4) {
-                        result = dc.runScript( (*iter) );
-                        continue;
+                OCL::CorbaDeploymentComponent dc( name, siteFile );
+
+                if (0 == TaskContextServer::Create( &dc, true, requireNameService ))
+                    {
+                        return -1;
                     }
-                    log(Error) << "Unknown extension of file: '"<< (*iter) <<"'. Must be xml, cpf for XML files or, ops or osd for script files."<<endlog();
+
+                // The orb thread accepts incomming CORBA calls.
+                TaskContextServer::ThreadOrb();
+
+                /* Only start the scripts after the Orb was created. Processing of
+                   scripts stops after the first failed script, and -1 is returned.
+                   Whether a script failed or all scripts succeeded, in non-daemon
+                   and non-checking mode the TaskBrowser will be run to allow
+                   inspection.
+                 */
+                bool result = true;
+                for (std::vector<std::string>::const_iterator iter=scriptFiles.begin();
+                     iter!=scriptFiles.end() && result;
+                     ++iter)
+                {
+                    if ( !(*iter).empty() )
+                    {
+                        if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
+                            if ( deploymentOnlyChecked ) {
+                                if (!dc.loadComponents( (*iter) )) {
+                                    result = false;
+                                    log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
+                                } else if (!dc.configureComponents()) {
+                                    result = false;
+                                    log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                }
+                                // else leave result=true and continue
+                            } else {
+                                result = dc.kickStart( (*iter) );
+                            }
+                            continue;
+                        } if ( (*iter).rfind(".ops",string::npos) == (*iter).length() - 4 || (*iter).rfind(".osd",string::npos) == (*iter).length() - 4) {
+                            result = dc.runScript( (*iter) );
+                            continue;
+                        }
+                        log(Error) << "Unknown extension of file: '"<< (*iter) <<"'. Must be xml, cpf for XML files or, ops or osd for script files."<<endlog();
+                    }
                 }
-            }
-            rc = (result ? 0 : -1);
+                rc = (result ? 0 : -1);
 
-            if ( !deploymentOnlyChecked && !vm.count("daemon") ) {
-                 OCL::TaskBrowser tb( &dc );
-                 tb.loop();
+                // We don't start an interactive console when we're a daemon
+                if ( !deploymentOnlyChecked && !vm.count("daemon") ) {
+                     OCL::TaskBrowser tb( &dc );
+                     tb.loop();
 
-                 // do it while CORBA is still up in case need to do anything remote.
-                 dc.shutdownDeployment();
+                     // do it while CORBA is still up in case need to do anything remote.
+                     dc.shutdownDeployment();
+                }
             }
 
             TaskContextServer::ShutdownOrb();

--- a/bin/deployer.cpp
+++ b/bin/deployer.cpp
@@ -203,7 +203,6 @@ int main(int argc, char** argv)
             // We don't start an interactive console when we're a daemon
             if ( !deploymentOnlyChecked && !vm.count("daemon") ) {
                 OCL::TaskBrowser tb( &dc );
-
                 tb.loop();
 
                 dc.shutdownDeployment();


### PR DESCRIPTION
This patch could potentially fix the deployer lock-up on quit bug (https://trello.com/c/xwu2HZzO/145-pc-lock-up-on-deployer-quit). It first destroys the CorbaDeploymentComponent and kicks-out all components before the ORB is shutdown and destroyed.

Because the `TaskContextServer` destructor accesses the TaskContext's name via the `getName()` method for logging, which already has been destroyed with this patch at the time the server is destroyed, it requires another patch in rtt (separate PR).

Unfortunately there is no clean mechanism in RTT to make sure that the server gets deregistered and destroyed at the moment the TaskContext is destroyed. So either all servers have to be destroyed before the components are actually stopped, cleaned up and unloaded (previous behavior) or the servers have to survive the destruction of the components (this patch).

CC: @psoetens, @smits
