### PR TITLE
Fixed OCL::Logging cleanup and TLSF memory pool destruction in deployer-corba

### DIFF
--- a/bin/cdeployer.cpp
+++ b/bin/cdeployer.cpp
@@ -22,9 +22,7 @@
  *   License along with this program; if not, write to the Free Software   *
  *   Foundation, Inc., 59 Temple Place,                                    *
  *   Suite 330, Boston, MA  02111-1307  USA                                *
- *                                                                         *
  ***************************************************************************/
-
 
 #include <rtt/rtt-config.h>
 #ifdef OS_RT_MALLOC
@@ -32,27 +30,26 @@
 #define ORO_MEMORY_POOL
 #include <rtt/os/tlsf/tlsf.h>
 #endif
-
 #include <rtt/os/main.h>
 #include <rtt/RTT.hpp>
+#include <rtt/Logger.hpp>
 
 #include <deployment/CorbaDeploymentComponent.hpp>
 #include <rtt/transports/corba/TaskContextServer.hpp>
 #include <iostream>
+#include <string>
 #include "deployer-funcs.hpp"
 
 #ifdef  ORO_BUILD_LOGGING
 #   ifndef OS_RT_MALLOC
-#   warning Logging needs rtalloc!
+#   warning "Logging needs rtalloc!"
 #   endif
 #include <log4cpp/HierarchyMaintainer.hh>
 #include "logging/Category.hpp"
 #endif
 
-using namespace std;
-using namespace RTT::corba;
 using namespace RTT;
-using namespace OCL;
+using namespace RTT::corba;
 namespace po = boost::program_options;
 
 int main(int argc, char** argv)
@@ -127,12 +124,13 @@ int main(int argc, char** argv)
 #ifdef  ORO_BUILD_RTALLOC
     size_t                  memSize     = rtallocMemorySize.size;
     void*                   rtMem       = 0;
+    size_t                  freeMem     = 0;
     if (0 < memSize)
     {
         // don't calloc() as is first thing TLSF does.
         rtMem = malloc(memSize);
-        assert(rtMem);
-        size_t freeMem = init_memory_pool(memSize, rtMem);
+        assert(0 != rtMem);
+        freeMem = init_memory_pool(memSize, rtMem);
         if ((size_t)-1 == freeMem)
         {
             cerr << "Invalid memory pool size of " << memSize
@@ -146,9 +144,11 @@ int main(int argc, char** argv)
 #endif  // ORO_BUILD_RTALLOC
 
 #ifdef  ORO_BUILD_LOGGING
+    // use our log4cpp-derived categories to do real-time logging
     log4cpp::HierarchyMaintainer::set_category_factory(
         OCL::logging::Category::createOCLCategory);
 #endif
+
 
     /******************** WARNING ***********************
      *   NO log(...) statements before __os_init() !!!!! 
@@ -160,84 +160,110 @@ int main(int argc, char** argv)
 #ifdef  ORO_BUILD_LOGGING
         log(Info) << "OCL factory set for real-time logging" << endlog();
 #endif
+        rc = -1;     // prove otherwise
         // scope to force dc destruction prior to memory free
-        {
-            OCL::CorbaDeploymentComponent dc( name, siteFile );
+        try {
             // if TAO options not found then have TAO process just the program name,
             // otherwise TAO processes the program name plus all options (potentially
             // none) after "--"
             TaskContextServer::InitOrb( argc - taoIndex, &argv[taoIndex] );
 
-            if (0 == TaskContextServer::Create( &dc, true, requireNameService ))
+            // scope to force dc destruction prior to memory free and Orb shutdown
             {
-                return -1;
-            }
+                OCL::CorbaDeploymentComponent dc( name, siteFile );
 
-            /* Only start the scripts after the Orb was created. Processing of
-               scripts stops after the first failed script, and -1 is returned.
-               Whether a script failed or all scripts succeeded, the CORBA
-               server will be run.
-             */
-            bool result = true;
-            for (std::vector<std::string>::const_iterator iter=scriptFiles.begin();
-                 iter!=scriptFiles.end() && result;
-                 ++iter)
-            {
-                if ( !(*iter).empty() )
-                {
-                    if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
-                        if ( deploymentOnlyChecked ) {
-                            if (!dc.loadComponents( (*iter) )) {
-                                result = false;
-                                log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
-                            } else if (!dc.configureComponents()) {
-                                result = false;
-                                log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
-                            }
-                            // else leave result=true and continue
-                        } else {
-                            result = dc.kickStart( (*iter) );
-                        }
-                        continue;
-                    } if ( (*iter).rfind(".ops",string::npos) == (*iter).length() - 4 || (*iter).rfind(".osd",string::npos) == (*iter).length() - 4) {
-                        result = dc.runScript( (*iter) );
-                        continue;
+                if (0 == TaskContextServer::Create( &dc, true, requireNameService ))
+                    {
+                        return -1;
                     }
-                    log(Error) << "Unknown extension of file: '"<< (*iter) <<"'. Must be xml, cpf for XML files or, ops or osd for script files."<<endlog();
-                }
-            }
-            rc = (result ? 0 : -1);
 
-            // Export the DeploymentComponent as CORBA server.
-            if ( !deploymentOnlyChecked ) {
-            	TaskContextServer::RunOrb();
+                /* Only start the scripts after the Orb was created. Processing of
+                   scripts stops after the first failed script, and -1 is returned.
+                   Whether a script failed or all scripts succeeded, the CORBA
+                   server will be run.
+                 */
+                bool result = true;
+                for (std::vector<std::string>::const_iterator iter=scriptFiles.begin();
+                     iter!=scriptFiles.end() && result;
+                     ++iter)
+                {
+                    if ( !(*iter).empty() )
+                    {
+                        if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
+                            if ( deploymentOnlyChecked ) {
+                                if (!dc.loadComponents( (*iter) )) {
+                                    result = false;
+                                    log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
+                                } else if (!dc.configureComponents()) {
+                                    result = false;
+                                    log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                }
+                                // else leave result=true and continue
+                            } else {
+                                result = dc.kickStart( (*iter) );
+                            }
+                            continue;
+                        } if ( (*iter).rfind(".ops",string::npos) == (*iter).length() - 4 || (*iter).rfind(".osd",string::npos) == (*iter).length() - 4) {
+                            result = dc.runScript( (*iter) );
+                            continue;
+                        }
+                        log(Error) << "Unknown extension of file: '"<< (*iter) <<"'. Must be xml, cpf for XML files or, ops or osd for script files."<<endlog();
+                    }
+                }
+                rc = (result ? 0 : -1);
+
+                // Export the DeploymentComponent as CORBA server.
+                if ( !deploymentOnlyChecked ) {
+                    TaskContextServer::RunOrb();
+                }
             }
 
             TaskContextServer::ShutdownOrb();
 
             TaskContextServer::DestroyOrb();
 
-        }
 
-        __os_exit();
+        } catch( CORBA::Exception &e ) {
+            log(Error) << argv[0] <<" ORO_main : CORBA exception raised!" << Logger::nl;
+            log() << CORBA_EXCEPTION_INFO(e) << endlog();
+        } catch (...) {
+            // catch this so that we can destroy the TLSF memory correctly
+            log(Error) << "Uncaught exception." << endlog();
+        }
+#ifdef  ORO_BUILD_RTALLOC
+        if (0 != rtMem)
+            {
+                // print statistics after deployment finished, but before os_exit() (needs Logger):
+                log(Debug) << "TLSF bytes allocated=" << memSize
+                           << " overhead=" << (memSize - freeMem)
+                           << " max-used=" << get_max_size(rtMem)
+                           << " currently-used=" << get_used_size(rtMem)
+                           << " still-allocated=" << (get_used_size(rtMem) - (memSize - freeMem))
+                           << endlog();
+            }
+#endif
+
+		// shutdown Orocos
+		__os_exit();
 	}
 	else
 	{
 		std::cerr << "Unable to start Orocos" << std::endl;
-        return -1;
+        rc = -1;
 	}
+
 #ifdef  ORO_BUILD_LOGGING
     log4cpp::HierarchyMaintainer::getDefaultMaintainer().shutdown();
     log4cpp::HierarchyMaintainer::getDefaultMaintainer().deleteAllCategories();
 #endif
 
 #ifdef  ORO_BUILD_RTALLOC
-    if (!rtMem)
+    if (0 != rtMem)
     {
         destroy_memory_pool(rtMem);
         free(rtMem);
     }
-#endif  // ORO_BUILD_RTALLOC
+#endif
 
     return rc;
 }

--- a/bin/deployer.cpp
+++ b/bin/deployer.cpp
@@ -56,7 +56,6 @@
 
 using namespace RTT;
 namespace po = boost::program_options;
-using namespace std;
 
 int main(int argc, char** argv)
 {
@@ -99,11 +98,10 @@ int main(int argc, char** argv)
     // if extra options not found then process all command line options,
     // otherwise process all options up to but not including "--"
     int rc = OCL::deployerParseCmdLine(!found ? argc : optIndex, argv,
-                                       siteFile, scriptFiles, name, requireNameService,deploymentOnlyChecked,
+                                       siteFile, scriptFiles, name, requireNameService, deploymentOnlyChecked,
 									   minNumberCPU,
                                        vm, &otherOptions);
-
-    if (0 != rc)
+	if (0 != rc)
 	{
 		return rc;
 	}
@@ -134,7 +132,7 @@ int main(int argc, char** argv)
         freeMem = init_memory_pool(memSize, rtMem);
         if ((size_t)-1 == freeMem)
         {
-            cerr << "Invalid memory pool size of " << memSize 
+            cerr << "Invalid memory pool size of " << memSize
                           << " bytes (TLSF has a several kilobyte overhead)." << endl;
             free(rtMem);
             return -1;
@@ -145,6 +143,7 @@ int main(int argc, char** argv)
 #endif  // ORO_BUILD_RTALLOC
 
 #ifdef  ORO_BUILD_LOGGING
+    // use our log4cpp-derived categories to do real-time logging
     log4cpp::HierarchyMaintainer::set_category_factory(
         OCL::logging::Category::createOCLCategory);
 #endif
@@ -160,6 +159,7 @@ int main(int argc, char** argv)
 #ifdef  ORO_BUILD_LOGGING
         log(Info) << "OCL factory set for real-time logging" << endlog();
 #endif
+        rc = -1;     // prove otherwise
         // scope to force dc destruction prior to memory free
         {
             OCL::DeploymentComponent dc( name, siteFile );
@@ -222,7 +222,8 @@ int main(int argc, char** argv)
             }
 #endif
 
-        __os_exit();
+		// shutdown Orocos
+		__os_exit();
 	}
 	else
 	{
@@ -238,13 +239,6 @@ int main(int argc, char** argv)
 #ifdef  ORO_BUILD_RTALLOC
     if (0 != rtMem)
     {
-        std::cout << "TLSF bytes allocated=" << memSize
-                  << " overhead=" << (memSize - freeMem)
-                  << " max-used=" << get_max_size(rtMem)
-                  << " currently-used=" << get_used_size(rtMem)
-                  << " still-allocated=" << (get_used_size(rtMem) - (memSize - freeMem))
-                  << "\n";
-
         destroy_memory_pool(rtMem);
         free(rtMem);
     }


### PR DESCRIPTION
...and some general syncs between deployer.cpp, deployer-corba.cpp and cdeployer.cpp.

Usage of white-space is quite inconsistent for those files. I only compared them with each other and synced differences for the exact same line of code in order to simplify future comparisons, but tried to update as few lines as possible within a single file. Best viewed with [?w=1](https://github.com/snrkiwi/ocl/pull/2/files?w=1) in GitHub to hide pure white-space changes.