### PR TITLE
deployment: fix configuration and unloading of remote components

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -1439,7 +1439,8 @@ namespace OCL
 
             // do not configure when not stopped.
             if ( peer->getTaskState() > Stopped) {
-                log(Warning) << "Component "<< peer->getName()<< " doesn't need to be configured (already Running)." <<endlog();
+                if (!compmap[comp.getName()].proxy)
+                    log(Warning) << "Component "<< peer->getName()<< " doesn't need to be configured (already Running)." <<endlog();
                 continue;
             }
 

--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -1846,45 +1846,48 @@ namespace OCL
         std::string  name = cit->first;
 
         if ( it->loaded && it->instance ) {
-            if ( !it->instance->isRunning() ) {
-                if (!it->proxy ) {
+            if (!it->proxy ) {
+                if ( !it->instance->isRunning() ) {
                     // allow subclasses to do cleanup too.
                     componentUnloaded( it->instance );
                     log(Debug) << "Disconnecting " <<name <<endlog();
                     it->instance->disconnect();
                     log(Debug) << "Terminating " <<name <<endlog();
-                } else
-                    log(Debug) << "Removing proxy for " <<name <<endlog();
-
-                // Lookup and erase port+owner from conmap.
-                for( ConMap::iterator cmit = conmap.begin(); cmit != conmap.end(); ++cmit) {
-                    size_t n = 0;
-                    while ( n != cmit->second.owners.size() ) {
-                        if (cmit->second.owners[n] == it->instance ) {
-                            cmit->second.owners.erase( cmit->second.owners.begin() + n );
-                            cmit->second.ports.erase( cmit->second.ports.begin() + n );
-                            n = 0;
-                        } else
-                            ++n;
-                    }
+                } else {
+                    log(Error) << "Could not unload Component "<< name <<": still running." <<endlog();
+                    return false;
                 }
-                // Lookup in the property configuration and remove:
-                RTT::Property<RTT::PropertyBag>* pcomp = root.getPropertyType<PropertyBag>(name);
-                if (pcomp) {
-                    root.removeProperty(pcomp);
-                }
+            } else
+                log(Debug) << "Removing proxy for " <<name <<endlog();
 
-                // Finally, delete the activity before the TC !
-                delete it->act;
-                it->act = 0;
-                ComponentLoader::Instance()->unloadComponent( it->instance );
-                it->instance = 0;
-                log(Info) << "Disconnected and destroyed "<< name <<endlog();
-            } else {
-                log(Error) << "Could not unload Component "<< name <<": still running." <<endlog();
-                valid=false;
+            // Lookup and erase port+owner from conmap.
+            for( ConMap::iterator cmit = conmap.begin(); cmit != conmap.end(); ++cmit) {
+                size_t n = 0;
+                while ( n != cmit->second.owners.size() ) {
+                    if (cmit->second.owners[n] == it->instance ) {
+                        cmit->second.owners.erase( cmit->second.owners.begin() + n );
+                        cmit->second.ports.erase( cmit->second.ports.begin() + n );
+                        n = 0;
+                    } else
+                        ++n;
+                }
             }
+            // Lookup in the property configuration and remove:
+            RTT::Property<RTT::PropertyBag>* pcomp = root.getPropertyType<PropertyBag>(name);
+            if (pcomp) {
+                root.removeProperty(pcomp);
+            }
+
+            // Finally, delete the activity before the TC !
+            // Note: Most likely it->act is a null pointer here and the ownership has already been transfered
+            // to the TaskContext.
+            delete it->act;
+            it->act = 0;
+            ComponentLoader::Instance()->unloadComponent( it->instance );
+            it->instance = 0;
+            log(Info) << "Disconnected and destroyed "<< name <<endlog();
         }
+
         if (valid) {
             // NOTE there is no reason to keep the ComponentData in the vector.
             // actually it may cause errors if we try to re-load the Component later.


### PR DESCRIPTION
If a deployment contains a remote component that is already running (e.g. due to a line like
```xml
<struct name="RemoteComponent" type="CORBA"></struct>
```
in the XML configuration), do not output a warning like:
```
2.137 [ Warning][configureComponents] Component RemoteComponent doesn't need to be configured (already Running). 
```
during the configuration step (https://github.com/snrkiwi/ocl/commit/27b53336228329a18d97052a8d7f1f6b39faaa64). If the tag additionally would have properties, an activity definition or scripts attached to it, they are silently ignored, **but only if the remote component is not yet running**.

Options:
- Only suppress the warning if neither is true (no additional tags)?
- Disallow most tags for proxy components other than ` <struct name="Peers" ...>` (for adding peers remotely) and `<struct name="Ports" ...>` (for adding new port connections)?

The second patch https://github.com/snrkiwi/ocl/commit/e9ef35241b629e765b1916efdfa04eb082f758ae fixes unloading of proxy components that are still running. Proxies are ignored during the stop and cleanup steps. So consequently unloading a proxy should only remove it from the local deployer but not change its run-time state or disconnect any ports, unless they connect to a component running in the local deployer that also has been unloaded. A typical log message without this patch would be:
```
5.743 [ ERROR  ][Thread] Could not unload Component RemoteComponent: still running.
5.743 [CRITICAL][Thread] Kick-out of group 1 failed:  unloadComponents() failed.
```